### PR TITLE
fix: updates to nightly mojo 25.5.0.dev2025062005

### DIFF
--- a/firehose/common.mojo
+++ b/firehose/common.mojo
@@ -4,8 +4,8 @@
 from builtin._location import __call_location, _SourceLocation
 
 
-@value
-struct Record:
+@fieldwise_init
+struct Record(Copyable & Movable):
     """
     Record: Represents a log message and its associated metadata.
 

--- a/firehose/filterers/default.mojo
+++ b/firehose/filterers/default.mojo
@@ -5,7 +5,6 @@ from firehose.filterers.common import LoggerFilter
 from firehose.common import Record
 
 
-@value
 struct DefaultLoggerFilter(LoggerFilter):
     """
     DefaultLoggerFilter: Standard log level-based filter.

--- a/firehose/formatters/default.mojo
+++ b/firehose/formatters/default.mojo
@@ -10,7 +10,7 @@ from firehose.formatters.formattable_string import FormattableString
 from firehose import LOG_LEVEL_NAMES_FROM_NUMERIC
 
 
-@value
+@fieldwise_init
 struct DefaultLoggerFormatter(LoggerFormatter):
     """
     DefaultLoggerFormatter: Standard pass-through message formatter.

--- a/firehose/formatters/formattable_string.mojo
+++ b/firehose/formatters/formattable_string.mojo
@@ -5,8 +5,8 @@ from collections.dict import Dict
 # First Party Modules
 
 
-@value
-struct FormattableString:
+@fieldwise_init
+struct FormattableString(Copyable & Movable):
     """
     FormattableString: A string that extracts metadata for a formatter to use
     when formatting a message.

--- a/firehose/outputters/default.mojo
+++ b/firehose/outputters/default.mojo
@@ -5,7 +5,7 @@ from firehose.outputters.common import LoggerOutputer
 from firehose.common import Record
 
 
-@value
+@fieldwise_init
 struct DefaultLoggerOutputer(LoggerOutputer):
     """
     DefaultLoggerOutputer: Standard console output implementation.

--- a/firehose/outputters/file_logger.mojo
+++ b/firehose/outputters/file_logger.mojo
@@ -7,7 +7,7 @@ from firehose.outputters.common import LoggerOutputer
 from firehose.common import Record
 
 
-@value
+@fieldwise_init
 struct FileLoggerOutputer(LoggerOutputer):
     """
     FileLoggerOutputer: Logs messages to a file.

--- a/firehose/outputters/test.mojo
+++ b/firehose/outputters/test.mojo
@@ -7,7 +7,7 @@ from firehose.outputters.common import LoggerOutputer
 from firehose.common import Record
 
 
-@value
+@fieldwise_init
 struct TestLoggerOutputer(LoggerOutputer):
     """
     TestLoggerOutputer: In-memory log message collector for testing.


### PR DESCRIPTION
- Switch remaining structs from `@value` to use `@fieldwise_init + Movable + Copyable`